### PR TITLE
fix load issue with .netstandard library

### DIFF
--- a/build/Eryph.CommonClient.psd1
+++ b/build/Eryph.CommonClient.psd1
@@ -42,10 +42,10 @@ PowerShellVersion = '5.1'
 # PowerShellHostVersion = ''
 
 # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# DotNetFrameworkVersion = ''
+DotNetFrameworkVersion = '4.61'
 
 # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# ClrVersion = ''
+ClrVersion = '4.0'
 
 # Processor architecture (None, X86, Amd64) required by this module
 # ProcessorArchitecture = ''

--- a/build/build-cmdlet.ps1
+++ b/build/build-cmdlet.ps1
@@ -34,8 +34,8 @@ mkdir coreclr | Out-Null
 mkdir desktop | Out-Null
 
 cp $rootDir\build\${cmdletName}* .
-cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\netcoreapp3.0\* coreclr -Exclude $excludedFiles -Recurse
-cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\net472\* desktop  -Exclude $excludedFiles  -Recurse
+cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\netcoreapp3.1\* coreclr -Exclude $excludedFiles -Recurse
+cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\net461\* desktop  -Exclude $excludedFiles  -Recurse
 
 $config = gc "${cmdletName}.psd1" -Raw
 $config = $config.Replace("ModuleVersion = '0.1'", "ModuleVersion = '${Env:GITVERSION_MajorMinorPatch}'");

--- a/src/Eryph.CommonClient.Commands/Eryph.CommonClient.Commands.csproj
+++ b/src/Eryph.CommonClient.Commands/Eryph.CommonClient.Commands.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net461</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/eryph-org/dotnet-commonclient</PackageProjectUrl>


### PR DESCRIPTION
use net 4.6.1 and netcore 3.1 (PS 5.1 and PS >=7.0 supported)

see also: https://docs.microsoft.com/en-us/powershell/scripting/dev-cross-plat/choosing-the-right-nuget-package?view=powershell-7.2#using-powershell-standard-with-different-net-runtimes